### PR TITLE
Add Bunny requirements documentation

### DIFF
--- a/website/pages/_meta.js
+++ b/website/pages/_meta.js
@@ -1,5 +1,5 @@
 export default {
-  index: "Hutch Tools",
+  index: "Hutch",
   contributing: "Contributing",
   relay: "Relay",
   bunny: "Bunny"

--- a/website/pages/bunny/deployment/_meta.js
+++ b/website/pages/bunny/deployment/_meta.js
@@ -1,4 +1,5 @@
 export default {
+  requirements: "Requirements",
   deployment: "Deploy Bunny",
   security: "Security Model",
   guidelines: "Security Guidelines",

--- a/website/pages/bunny/deployment/requirements.mdx
+++ b/website/pages/bunny/deployment/requirements.mdx
@@ -10,7 +10,6 @@
 | Network             | Outbound HTTPS (port 443)                                   |
 | Database Access     | OMOP CDM PostgreSQL / SQLServer                             |
 
-Notes: 
 - Any operating system that supports running containers is sufficient.
 - Requirements may vary depending on workload and deployment environment.
 
@@ -31,7 +30,7 @@ Recommended tables and field names:
 | Observation            | observation_id, person_id, observation_concept_id, observation_date                     |
 | Measurement            | measurement_id, person_id, measurement_concept_id, measurement_date                     |
 
-*Different from the HDR Gateway minimum data model.
+_*Not included in the HDR Gateway minimum data model._
 
 The following indexes are also recommended from the CDM to ensure queries are processed quickly.
 

--- a/website/pages/bunny/deployment/requirements.mdx
+++ b/website/pages/bunny/deployment/requirements.mdx
@@ -1,0 +1,19 @@
+# Requirements
+
+## System 
+
+| Requirement         | Minumum Specification              |
+|---------------------|------------------------------------|
+| CPU                 | 2 vCPUs                            |
+| Memory (RAM)        | 4 GB                               |
+| Storage             | 10 GB SSD                          |
+| Container Runtime   | Docker 24.x / Podman latest        |
+| Network             | Outbound HTTPS (port 443)          |
+| Database Access     | OMOP CDM PostgreSQL / SQLServer    |
+
+Notes: 
+- Any operating system that supports running containers is sufficient.
+- Requirements may vary depending on workload and deployment environment.
+
+## OMOP CDM
+

--- a/website/pages/bunny/deployment/requirements.mdx
+++ b/website/pages/bunny/deployment/requirements.mdx
@@ -2,14 +2,13 @@
 
 ## System 
 
-| Requirement         | Minumum Specification              |
-|---------------------|------------------------------------|
-| CPU                 | 2 vCPUs                            |
-| Memory (RAM)        | 4 GB                               |
-| Storage             | 10 GB SSD                          |
-| Container Runtime   | Docker 24.x / Podman latest        |
-| Network             | Outbound HTTPS (port 443)          |
-| Database Access     | OMOP CDM PostgreSQL / SQLServer    |
+| Requirement         | Minimum Specification                                       |
+|---------------------|-------------------------------------------------------------|
+| CPU                 | 2 vCPUs                                                     |
+| Memory (RAM)        | 4 GB                                                        |
+| Container Runtime   | OCI-compliant container runtime (Docker, Podman, Kubernetes)|
+| Network             | Outbound HTTPS (port 443)                                   |
+| Database Access     | OMOP CDM PostgreSQL / SQLServer                             |
 
 Notes: 
 - Any operating system that supports running containers is sufficient.
@@ -34,7 +33,7 @@ Recommended tables and field names:
 
 *Different from the HDR Gateway minimum data model.
 
-Additionally the following indexes are recommended from the CDM to ensure queries are processed quickly.
+The following indexes are also recommended from the CDM to ensure queries are processed quickly.
 
 | OMOP Table             | Recommended Indexes                |
 |------------------------|------------------------------------|

--- a/website/pages/bunny/deployment/requirements.mdx
+++ b/website/pages/bunny/deployment/requirements.mdx
@@ -19,19 +19,18 @@ Notes:
 
 Bunny requires an [OMOP CDM](https://ohdsi.github.io/CommonDataModel/background.html) database to query for data.
 
-Ideally the database should comply with the common data model, and the minimum data model that Bunny needs is slightly different [than outlined](https://healthdatagateway.org/en/data-custodian/support/cohort-discovery) on the HDR Gateway. 
+Ideally the database should comply with the common data model, and the minimum data model that Bunny requires is slightly different than the [HDR Gateway](https://healthdatagateway.org/en/data-custodian/support/cohort-discovery). 
 
 Recommended tables and field names:
 
-| OMOP Table            | OMOP Field Names                                                                        |
-|------------------------|----------------------------------------------------------------------------------------|
+| OMOP Table            | OMOP Field Names                                                                         |
+|------------------------|-----------------------------------------------------------------------------------------|
 | Person                 | person_id, gender_concept_id, year_of_birth, race_concept_id, **ethnicity_concept_id*** |
-| Condition Occurrence   | condition_occurrence_id, person_id, condition_concept_id, condition_start_date         |
-| Procedure Occurrence   | procedure_occurrence_id, person_id, procedure_concept_id, procedure_date               |
-| Drug Exposure          | drug_exposure_id, person_id, drug_concept_id, drug_exposure_start_date                 |
-| Observation            | observation_id, person_id, observation_concept_id, observation_date                    |
-| Measurement            | measurement_id, person_id, measurement_concept_id, measurement_date                    |
-| **Concept***            | **concept_id***, **domain_id***                                                          |
+| **Concept***           | **concept_id***, **domain_id***                                                         |
+| Condition Occurrence   | condition_occurrence_id, person_id, condition_concept_id, condition_start_date          |
+| Drug Exposure          | drug_exposure_id, person_id, drug_concept_id, drug_exposure_start_date                  |
+| Observation            | observation_id, person_id, observation_concept_id, observation_date                     |
+| Measurement            | measurement_id, person_id, measurement_concept_id, measurement_date                     |
 
 *Different from the HDR Gateway minimum data model.
 

--- a/website/pages/bunny/deployment/requirements.mdx
+++ b/website/pages/bunny/deployment/requirements.mdx
@@ -17,3 +17,30 @@ Notes:
 
 ## OMOP CDM
 
+Bunny requires an [OMOP CDM](https://ohdsi.github.io/CommonDataModel/background.html) database to query for data.
+
+Ideally the database should comply with the common data model, and the minimum data model that Bunny needs is slightly different [than outlined](https://healthdatagateway.org/en/data-custodian/support/cohort-discovery) on the HDR Gateway. 
+
+Recommended tables and field names:
+
+| OMOP Table            | OMOP Field Names                                                                        |
+|------------------------|----------------------------------------------------------------------------------------|
+| Person                 | person_id, gender_concept_id, year_of_birth, race_concept_id, **ethnicity_concept_id*** |
+| Condition Occurrence   | condition_occurrence_id, person_id, condition_concept_id, condition_start_date         |
+| Procedure Occurrence   | procedure_occurrence_id, person_id, procedure_concept_id, procedure_date               |
+| Drug Exposure          | drug_exposure_id, person_id, drug_concept_id, drug_exposure_start_date                 |
+| Observation            | observation_id, person_id, observation_concept_id, observation_date                    |
+| Measurement            | measurement_id, person_id, measurement_concept_id, measurement_date                    |
+| **Concept***            | **concept_id***, **domain_id***                                                          |
+
+*Different from the HDR Gateway minimum data model.
+
+Additionally the following indexes are recommended from the CDM to ensure queries are processed quickly.
+
+| OMOP Table             | Recommended Indexes                |
+|------------------------|------------------------------------|
+| Person                 | idx_person_id                      |
+| Concept                | idx_concept_concept_id             |
+| Condition Occurrence   | idx_condition_concept_id_1         |
+| Observation            | idx_observation_concept_id_1       |
+| Measurement            | idx_measurement_concept_id_1       |


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
📝 Documentation

## PR Description
Adds "Requirements" page to Bunny section, that details the system, and OMOP CDM requirements for Bunny.

Those specs will comfortably run several Bunny's for Cohort Discovery, useful to have to point to, but also make it clear the OMOP CDM is different than outlined by HDR.

## Related Issues or other material
Closes #100 
Closes #99 
